### PR TITLE
Prevent selection of bits while using drag functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
     border: 1px solid #000;
     padding: 5px 2px;
     font-size: 14px;
+    user-select: none;
   }
 
   .zerox-col {


### PR DESCRIPTION
When dragging across the bits to switch several of them at once, they would get selected as text. This behaviour was quite annoying so I added `user-select: none` to the input class. However, this also causes the labels above the bits to be unselectable, though I decided that's probably useful too in most cases. I think 90% of people won't mind not being able to copy a two digit number.